### PR TITLE
Search webview

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
-	let disposable: vscode.Disposable = vscode.commands.registerTextEditorCommand(
+	const disposable: vscode.Disposable = vscode.commands.registerTextEditorCommand(
 		'giflens',
 		searchHandler
 	);

--- a/src/search.ts
+++ b/src/search.ts
@@ -37,12 +37,8 @@ const webviewHtml: (imagesHtml: string) => string = (imagesHtml: string) =>
     </html>`;
 
 const search = async (editor: vscode.TextEditor) => {
-	// TODO check that the selection is empty
-	// TODO check that we are in a comment
 	// grabbing the current location to insert the edit later with the GIFLENS tag
 	const position: vscode.Position = editor.selection.active;
-	// creating a container to collect the url of the image selected
-	// let urlToUse: string = '';
 	// The code you place here will be executed every time your command is executed
 	const searchInput: string | undefined = await vscode.window.showInputBox({
 		placeHolder: 'your gif search',
@@ -86,8 +82,10 @@ const search = async (editor: vscode.TextEditor) => {
 		});
 
 		editor.edit(editBuilder => {
-			// goes to the begining of the line to create the GIFLENS tag the line above after insertion
+			// goes to the beginning of the line to create the GIFLENS tag the line above after insertion
 			let positionToInsert = new vscode.Position(position.line, 0);
+			// TODO when adding the GIFLENS comment, would be great to use the same indentation as surrounding code
+			// TODO when the line is empty, do not create an extra line (remove the \r)
 			editBuilder.insert(
 				positionToInsert,
 				`${getLanguageCommentStart()} GIFLENS-${urlToUse}\r`
@@ -99,12 +97,8 @@ const search = async (editor: vscode.TextEditor) => {
 	}
 };
 
-const createImages = (urls: string[]) => {
-	let images: string = '';
-	for (let url of urls) {
-		images += `<img class="search-img" src="${url}" />`;
-	}
-	return images;
+const createImages: (urls: string[]) => string = (urls: string[]) => {
+	return urls.map(url => `<img class="search-img" src="${url}" />`).join('');
 };
 
 // for later, maybe find the comment characters from the current language


### PR DESCRIPTION
Ticket: https://github.com/fallanic/GifLens/projects/1#card-17109594
Linked PRs: (links to corresponding PRs, optional)

## Changes

- the command for search is a TextEditorCommand to get access to the active text editor [https://code.visualstudio.com/api/references/vscode-api#commands.registerTextEditorCommand]
- search uses the utils to get the results of the search entered by the user in the prompt
- a webview is created to display the gifs given back by giphy
- clicking on a GIF sends back its url to the extension host environment, which then edits the active text editor to create a GIFLENS Tag with the url (and thus the gif is displayed in the hover)

## How To Test

- npm i
- use shift+cmd+p then look for the giflens command
- enter a search for giphy in the prompt
- click on one of the images
- check that a GIFLENS tag was created above the line on which your cursor was prior to starting the command

## Applicable Research Resources

- [https://code.visualstudio.com/api/extension-guides/webview]
